### PR TITLE
Grant config access to ngrok v3 default path (~/.config/ngrok)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,6 +39,7 @@ plugs:
     interface: personal-files
     write:
     - $HOME/.ngrok2
+    - $HOME/.config/ngrok
 
 apps:
   ngrok:


### PR DESCRIPTION
ngrok v3 defaults its config to `~/.config/ngrok/ngrok.yml` (Go's
`os.UserConfigDir()`), but the `ngrok-config` personal-files plug only grants the
legacy v2 path `~/.ngrok2`. Under strict confinement the v3 default is therefore
blocked, so `ngrok config add-authtoken` and any config read fail with
`permission denied` on a clean install.

This adds the v3 default path to the existing plug, keeping `~/.ngrok2` for
backward compatibility.

> ⚠️ `personal-files` is a privileged interface, so this new path will also need
> a Snap Store **auto-connect** grant (snapcraft-forum request) before it
> auto-connects for users — the same review the original `~/.ngrok2` grant went
> through. Without it, users would have to run `snap connect ngrok:ngrok-config`
> manually.

### Reproduce (before this change)

```
$ snap install ngrok
$ ngrok config add-authtoken <token>
ERROR:  Failed to save authtoken to configuration file
'/home/<user>/.config/ngrok/ngrok.yml': mkdir /home/<user>/.config/ngrok: permission denied
```

AppArmor confirms it's confinement, not file permissions:

```
apparmor="DENIED" operation="mkdir" profile="snap.ngrok.ngrok" name="/home/<user>/.config/ngrok/"
```

Fixes #102.
